### PR TITLE
depot/bolt: allow setting or OrgUnit in CA

### DIFF
--- a/depot/bolt/depot.go
+++ b/depot/bolt/depot.go
@@ -233,7 +233,7 @@ func (db *Depot) CreateOrLoadKey(bits int) (*rsa.PrivateKey, error) {
 	return key, nil
 }
 
-func (db *Depot) CreateOrLoadCA(key *rsa.PrivateKey, years int, org, country string) (*x509.Certificate, error) {
+func (db *Depot) CreateOrLoadCA(key *rsa.PrivateKey, years int, org, orgUnit, country string) (*x509.Certificate, error) {
 	var (
 		cert *x509.Certificate
 		err  error
@@ -260,7 +260,7 @@ func (db *Depot) CreateOrLoadCA(key *rsa.PrivateKey, years int, org, country str
 	subject := pkix.Name{
 		Country:            []string{country},
 		Organization:       []string{org},
-		OrganizationalUnit: []string{"MICROMDM SCEP CA"},
+		OrganizationalUnit: []string{orgUnit},
 		Locality:           nil,
 		Province:           nil,
 		StreetAddress:      nil,

--- a/depot/bolt/depot_test.go
+++ b/depot/bolt/depot_test.go
@@ -141,7 +141,7 @@ func TestDepot_CreateOrLoadCA(t *testing.T) {
 			t.Fatalf("%d. Depot.CreateOrLoadKey() error = %v", i, err)
 		}
 
-		if _, err := db.CreateOrLoadCA(key, 10, "MicroMDM", "US"); (err != nil) != tt.wantErr {
+		if _, err := db.CreateOrLoadCA(key, 10, "MicroMDM", "MICROMDM SCEP CA", "US"); (err != nil) != tt.wantErr {
 			t.Errorf("%d. Depot.CreateOrLoadCA() error = %v, wantErr %v", i, err, tt.wantErr)
 		}
 	}

--- a/server/service_bolt_test.go
+++ b/server/service_bolt_test.go
@@ -27,7 +27,7 @@ func TestDynamicChallenge(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = depot.CreateOrLoadCA(key, 5, "MicroMDM", "US")
+	_, err = depot.CreateOrLoadCA(key, 5, "MicroMDM", "MICROMDM SCEP CA", "US")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This commit is positioned after the last stable release of the `scep` package referenced in the [go.mod](https://github.com/imperosoftware/micromdm/blob/1ad25cb8d857b776ad6f34c131f87cd830d82eff/go.mod) of our [forked version of micromdm](https://github.com/imperosoftware/micromdm/pull/1/files).

Should we choose to merge this, we cannot delete the branch as we'll lose the commit being referenced.